### PR TITLE
Fix issue with README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,17 @@
 
 The `cloud.terraform` collection supports running Terraform in sync with Ansible.
 
+<!--start requires_ansible-->
 ## Ansible version compatibility
 
-This collection requires Ansible Core 2.13 or later and thus Python 3.8 or later.
+This collection has been tested against following Ansible versions: **>= 2.13.0**.
+
+For collections that support Ansible 2.9, please ensure you update your `network_os` to use the
+fully qualified collection name (for example, `cisco.ios.ios`).
+Plugins and modules within a collection may be tested with only specific Ansible versions.
+A collection may contain metadata that identifies these versions.
+PEP440 is the schema used to describe the versions of Ansible.
+<!--end requires_ansible-->
 
 ## Included content
 <!--start collection content-->

--- a/changelogs/fragments/fix_readme.yaml
+++ b/changelogs/fragments/fix_readme.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Fix README.md to include requires_ansible section. (https://github.com/ansible-collections/cloud.terraform/pull/5)

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 
 namespace: cloud
 name: terraform
-version: 1.0.0
+version: 1.0.1
 readme: README.md
 authors:
   - Ansible (https://github.com/ansible)


### PR DESCRIPTION
`ansible-galaxy collection publish` is failing due to missing `requires_ansible` section
the error was 
```
[ERROR]: Galaxy import error message: Import Task "23822" failed:
'requires_ansible' is not a valid semantic_version requirement specification
```