### PR TITLE
meta/runtime.yml requires_ansible drop the space

### DIFF
--- a/changelogs/fragments/drop_sapce_in_requires_ansible.yaml
+++ b/changelogs/fragments/drop_sapce_in_requires_ansible.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- "meta/runtime.yml - Drop space in requires_ansible that was preventing the upload on Galaxy (https://github.com/ansible-collections/cloud.terraform/pull/8)."

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: ">= 2.13.0"
+requires_ansible: ">=2.13.0"
 action_groups:
   terraform:
     - terraform


### PR DESCRIPTION
This was triggering the following error:

```
plugins/module_utils/version.py:19:9: F401 'distutils.version.LooseVersion' imported but unused 
Import Task "23904" failed: 'requires_ansible' is not a valid semantic_version requirement specification 
```
