### PR TITLE
meta/runtime.yml requires_ansible drop the space (#8)

### DIFF
--- a/changelogs/fragments/drop_sapce_in_requires_ansible.yaml
+++ b/changelogs/fragments/drop_sapce_in_requires_ansible.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- "meta/runtime.yml - Drop space in requires_ansible that was preventing the upload on Galaxy (https://github.com/ansible-collections/cloud.terraform/pull/8)."

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: ">= 2.13.0"
+requires_ansible: ">=2.13.0"
 action_groups:
   terraform:
     - terraform


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
meta/runtime.yml requires_ansible drop the space

This was triggering the following error:
plugins/module_utils/version.py:19:9: F401 'distutils.version.LooseVersion' imported but unused  Import Task "23904" failed: 'requires_ansible' is not a valid semantic_version requirement specification 

Reviewed-by: Mike Graves <mgraves@redhat.com>
(cherry picked from commit f9e0113034962556a19515dc47edbeb3572eaaa1)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
