### PR TITLE
Use ubuntu-2004 instead of ubuntu-latest in CI.

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -16,7 +16,7 @@ jobs:
         ansible:
           - stable-2.13
           - stable-2.14
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Perform sanity testing
         uses: ansible-community/ansible-test-gh-action@release/v1
@@ -25,7 +25,7 @@ jobs:
           testing-type: sanity
 
   units:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Units (Ⓐ${{ matrix.ansible }})
     strategy:
       fail-fast: true
@@ -43,7 +43,7 @@ jobs:
           testing-type: units
 
   integration:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: I (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }}+tf${{ matrix.terraform }})
     strategy:
       fail-fast: false

--- a/.github/workflows/extra-docs-linting.yml
+++ b/.github/workflows/extra-docs-linting.yml
@@ -13,7 +13,7 @@ jobs:
     name: Lint extra docsite docs and links
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out code
         uses: actions/checkout@v3


### PR DESCRIPTION
`ansible-test --docker` failing due to incompatible images.

Caused by a changed ubuntu-latest default from 20.04 to 22.04 on 2022-12.

Related: https://github.com/ansible/ansible/issues/79524