### PR TITLE
Change order of name and state_file in command

### DIFF
--- a/changelogs/fragments/change_name_and_state_order_in_terraform_command.yaml
+++ b/changelogs/fragments/change_name_and_state_order_in_terraform_command.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - terraform_output module - when providing name and state_file parameters, the value of the requested output wasn't returned.
+    This issue was solved by changing the order of the name and state parameters in the invoked Terraform command (https://github.com/ansible-collections/cloud.terraform/pull/19).

--- a/plugins/modules/terraform_output.py
+++ b/plugins/modules/terraform_output.py
@@ -130,7 +130,7 @@ def get_outputs(terraform_binary, project_path, state_file, output_format, name=
         "-no-color",
         "-{0}".format(output_format)
     ]
-    outputs_command += ([name] if name else []) + _state_args(state_file)
+    outputs_command += _state_args(state_file) + ([name] if name else [])
     rc, outputs_text, outputs_err = module.run_command(
         outputs_command, cwd=project_path
     )

--- a/tests/integration/targets/terraform_output/tasks/main.yml
+++ b/tests/integration/targets/terraform_output/tasks/main.yml
@@ -85,12 +85,13 @@
       - terraform_output.outputs.my_output.value == "file generated"
       - terraform_output.value is not defined
 
-- name: Delete results
-  cloud.terraform.terraform:
-    project_path: "{{ test_basedir }}"
-    state: absent
-  register: terraform_result
-  check_mode: false
+- name: Terraform checkout - specified state file and specified output
+  cloud.terraform.terraform_output:
+    state_file: "{{ test_basedir }}/mycustomstate.tfstate"
+    name: my_output
+  register: terraform_output
 - assert:
     that:
-      - terraform_result is changed
+      - terraform_output is not changed
+      - terraform_output.outputs is not defined
+      - terraform_output.value == "file generated"


### PR DESCRIPTION
##### SUMMARY
In the outputs_command "name" and "-state" parameters needed to be swaped, to be able to get the desired value in case if both parameters are provided.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
terraform_output module
