### PR TITLE
Inventory plugin bugfix - changed group and host name

### DIFF
--- a/changelogs/fragments/terraform_provider_update_host_and_group_name.yaml
+++ b/changelogs/fragments/terraform_provider_update_host_and_group_name.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Updated host and group name in cloud.terraform.terraform_provider inventory plugin. (https://github.com/ansible-collections/cloud.terraform/pull/34)

--- a/plugins/inventory/terraform_provider.py
+++ b/plugins/inventory/terraform_provider.py
@@ -156,25 +156,25 @@ class InventoryModule(BaseInventoryPlugin):  # type: ignore  # mypy ignore
 
     def _add_group(self, inventory: Any, resource: TerraformRootModuleResource) -> None:
         attributes = TerraformAnsibleProvider.from_json(resource)
-        inventory.add_group(attributes.group_name)
+        inventory.add_group(attributes.name)
         if attributes.children:
             for child in attributes.children:
                 inventory.add_group(child)
-                inventory.add_child(attributes.group_name, child)
+                inventory.add_child(attributes.name, child)
         if attributes.variables:
             for key, value in attributes.variables.items():
-                inventory.set_variable(attributes.group_name, key, value)
+                inventory.set_variable(attributes.name, key, value)
 
     def _add_host(self, inventory: Any, resource: TerraformRootModuleResource) -> None:
         attributes = TerraformAnsibleProvider.from_json(resource)
-        inventory.add_host(attributes.host_name)
+        inventory.add_host(attributes.name)
         if attributes.groups:
             for group in attributes.groups:
                 inventory.add_group(group)
-                inventory.add_host(attributes.host_name, group=group)
+                inventory.add_host(attributes.name, group=group)
         if attributes.variables:
             for key, value in attributes.variables.items():
-                inventory.set_variable(attributes.host_name, key, value)
+                inventory.set_variable(attributes.name, key, value)
 
     def create_inventory(self, inventory: Any, state_content: TerraformShow) -> None:
         for resource in state_content.values.root_module.resources:

--- a/plugins/module_utils/models.py
+++ b/plugins/module_utils/models.py
@@ -54,18 +54,16 @@ class TerraformRootModuleResource:
 
 @dataclass
 class TerraformAnsibleProvider:
-    host_name: str
+    name: str
     groups: List[str]
-    group_name: str
     children: List[str]
     variables: Dict[str, str]
 
     @classmethod
     def from_json(cls, json: TerraformRootModuleResource) -> "TerraformAnsibleProvider":
         return cls(
-            host_name=json.values.get("host_name", None),
+            name=json.values.get("name", None),
             groups=json.values.get("groups", []),
-            group_name=json.values.get("group_name", None),
             children=json.values.get("children", []),
             variables=json.values.get("variables", {}),
         )

--- a/tests/integration/targets/terraform_provider/ansible_provider.tf
+++ b/tests/integration/targets/terraform_provider/ansible_provider.tf
@@ -9,36 +9,36 @@ terraform {
 }
 
 resource "ansible_host" "host" {
-  host_name = "somehost"
+  name   = "somehost"
   groups = ["somegroup", "anothergroup"]
   variables = {
-    host_hello = "from host!"
+    host_hello    = "from host!"
     host_variable = 7
   }
 }
 
 resource "ansible_host" "anotherhost" {
-  host_name = "anotherhost"
+  name   = "anotherhost"
   groups = ["somechild"]
   variables = {
-    host_hello = "from anotherhost!"
+    host_hello    = "from anotherhost!"
     host_variable = 5
   }
 }
 
 resource "ansible_host" "ungrupedhost" {
-  host_name = "ungrupedhost"
+  name = "ungrupedhost"
 }
 
 resource "ansible_group" "group" {
-  group_name = "somegroup"
+  name     = "somegroup"
   children = ["somechild", "anotherchild"]
   variables = {
-    group_hello = "from group!",
+    group_hello    = "from group!",
     group_variable = 11
   }
 }
 
 resource "ansible_group" "childlessgroup" {
-  group_name = "childlessgroup"
+  name = "childlessgroup"
 }

--- a/tests/integration/targets/terraform_provider/terraform.tfstateshow
+++ b/tests/integration/targets/terraform_provider/terraform.tfstateshow
@@ -13,7 +13,7 @@
           "schema_version": 0,
           "values": {
             "children": null,
-            "group_name": "childlessgroup",
+            "name": "childlessgroup",
             "id": "childlessgroup",
             "variables": null
           },
@@ -31,7 +31,7 @@
               "somechild",
               "anotherchild"
             ],
-            "group_name": "somegroup",
+            "name": "somegroup",
             "id": "somegroup",
             "variables": {
               "group_variable": "11",
@@ -57,7 +57,7 @@
             "groups": [
               "somechild"
             ],
-            "host_name": "anotherhost",
+            "name": "anotherhost",
             "id": "anotherhost",
             "variables": {
               "host_hello": "from anotherhost!",
@@ -83,7 +83,7 @@
               "somegroup",
               "anothergroup"
             ],
-            "host_name": "somehost",
+            "name": "somehost",
             "id": "somehost",
             "variables": {
               "host_hello": "from host!",
@@ -107,7 +107,7 @@
           "schema_version": 0,
           "values": {
             "groups": null,
-            "host_name": "ungrupedhost",
+            "name": "ungrupedhost",
             "id": "ungrupedhost",
             "variables": null
           },

--- a/tests/unit/plugins/inventory/test_terraform_provider.py
+++ b/tests/unit/plugins/inventory/test_terraform_provider.py
@@ -93,9 +93,8 @@ class TestInventoryModuleAddHost:
         mocker.patch(
             "ansible_collections.cloud.terraform.plugins.inventory.terraform_provider.TerraformAnsibleProvider.from_json"
         ).return_value = TerraformAnsibleProvider(
-            host_name="host_name",
+            name="host_name",
             groups=["group1", "group2"],
-            group_name=None,
             children=[],
             variables={"host_var1": "1", "host_var2": "2"},
         )
@@ -112,9 +111,8 @@ class TestInventoryModuleAddHost:
         mocker.patch(
             "ansible_collections.cloud.terraform.plugins.inventory.terraform_provider.TerraformAnsibleProvider.from_json"
         ).return_value = TerraformAnsibleProvider(
-            host_name="host_name",
+            name="host_name",
             groups=["group1", "group2"],
-            group_name=None,
             children=[],
             variables={},
         )
@@ -129,9 +127,8 @@ class TestInventoryModuleAddHost:
         mocker.patch(
             "ansible_collections.cloud.terraform.plugins.inventory.terraform_provider.TerraformAnsibleProvider.from_json"
         ).return_value = TerraformAnsibleProvider(
-            host_name="host_name",
+            name="host_name",
             groups=[],
-            group_name=None,
             children=[],
             variables={"host_var1": "1", "host_var2": "2"},
         )
@@ -148,9 +145,8 @@ class TestInventoryModuleAddGroup:
         mocker.patch(
             "ansible_collections.cloud.terraform.plugins.inventory.terraform_provider.TerraformAnsibleProvider.from_json"
         ).return_value = TerraformAnsibleProvider(
-            host_name=None,
             groups=[],
-            group_name="group_name",
+            name="group_name",
             children=["child1", "child2"],
             variables={"group_var1": "1", "group_var2": "2"},
         )
@@ -167,9 +163,8 @@ class TestInventoryModuleAddGroup:
         mocker.patch(
             "ansible_collections.cloud.terraform.plugins.inventory.terraform_provider.TerraformAnsibleProvider.from_json"
         ).return_value = TerraformAnsibleProvider(
-            host_name=None,
             groups=[],
-            group_name="group_name",
+            name="group_name",
             children=["child1", "child2"],
             variables={},
         )
@@ -184,9 +179,8 @@ class TestInventoryModuleAddGroup:
         mocker.patch(
             "ansible_collections.cloud.terraform.plugins.inventory.terraform_provider.TerraformAnsibleProvider.from_json"
         ).return_value = TerraformAnsibleProvider(
-            host_name=None,
             groups=[],
-            group_name="group_name",
+            name="group_name",
             children=[],
             variables={"group_var1": "1", "group_var2": "2"},
         )
@@ -216,7 +210,7 @@ class TestCreateInventory:
                             schema_version=0,
                             values={
                                 "children": None,
-                                "group_name": "childlessgroup",
+                                "name": "childlessgroup",
                                 "id": "childlessgroup",
                                 "variables": None,
                             },
@@ -232,7 +226,7 @@ class TestCreateInventory:
                             schema_version=0,
                             values={
                                 "children": ["somechild", "anotherchild"],
-                                "group_name": "somegroup",
+                                "name": "somegroup",
                                 "id": "somegroup",
                                 "variables": {"group_hello": "from somegroup!", "group_variable": "11"},
                             },
@@ -248,7 +242,7 @@ class TestCreateInventory:
                             schema_version=0,
                             values={
                                 "groups": ["somechild"],
-                                "host_name": "anotherhost",
+                                "name": "anotherhost",
                                 "id": "anotherhost",
                                 "variables": {"host_hello": "from anotherhost!", "host_variable": "5"},
                             },
@@ -264,7 +258,7 @@ class TestCreateInventory:
                             schema_version=0,
                             values={
                                 "groups": ["somegroup", "anothergroup"],
-                                "host_name": "somehost",
+                                "name": "somehost",
                                 "id": "somehost",
                                 "variables": {"host_hello": "from somehost!", "host_variable": "7"},
                             },
@@ -280,7 +274,7 @@ class TestCreateInventory:
                             schema_version=0,
                             values={
                                 "groups": None,
-                                "host_name": "ungroupedhost",
+                                "name": "ungroupedhost",
                                 "id": "ungroupedhost",
                                 "variables": None,
                             },


### PR DESCRIPTION
##### SUMMARY
In inventory plugin terraform_provider.py names of the host and group needed to be updated to be consistent with terraform provider terraform-ansible-provider, thus enabling inventory plugin to work.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
terraform_provider.py
