### PR TITLE
Remove mutually exclusive for state_file and project_path

### DIFF
--- a/docs/cloud.terraform.inventory_from_outputs_role.rst
+++ b/docs/cloud.terraform.inventory_from_outputs_role.rst
@@ -357,7 +357,9 @@ Parameters
 
       The path to the root of the Terraform directory with the .tfstate file.
 
-      Mutually exclusive with state\_file.
+      If \ :emphasis:`state\_file`\  and \ :emphasis:`project\_path`\  are not specified, the \ :literal:`terraform.tfstate`\  file in the current working directory will be used.
+
+      The \ :literal:`TF\_DATA\_DIR`\  environment variable is respected.
 
 
       .. raw:: html
@@ -397,9 +399,11 @@ Parameters
 
         <div class="ansible-option-cell">
 
-      An absolute path to an existing Terraform state file.
+      The path to an existing Terraform state file.
 
-      Mutually exclusive with project\_path.
+      If \ :emphasis:`state\_file`\  and \ :emphasis:`project\_path`\  are not specified, the \ :literal:`terraform.tfstate`\  file in the current working directory will be used.
+
+      The \ :literal:`TF\_DATA\_DIR`\  environment variable is respected.
 
 
       .. raw:: html

--- a/roles/inventory_from_outputs/meta/argument_specs.yml
+++ b/roles/inventory_from_outputs/meta/argument_specs.yml
@@ -8,13 +8,17 @@ argument_specs:
       project_path:
         description:
           - The path to the root of the Terraform directory with the .tfstate file.
-          - Mutually exclusive with state_file.
+          - If I(state_file) and I(project_path) are not specified, the C(terraform.tfstate) file in the
+            current working directory will be used.
+          - The C(TF_DATA_DIR) environment variable is respected.
         type: path
         version_added: 1.0.0
       state_file:
         description:
-          - An absolute path to an existing Terraform state file.
-          - Mutually exclusive with project_path.
+          - The path to an existing Terraform state file.
+          - If I(state_file) and I(project_path) are not specified, the C(terraform.tfstate) file in the
+            current working directory will be used.
+          - The C(TF_DATA_DIR) environment variable is respected.
         type: path
         version_added: 1.0.0
       mapping_variables:

--- a/roles/inventory_from_outputs/tasks/main.yml
+++ b/roles/inventory_from_outputs/tasks/main.yml
@@ -1,21 +1,9 @@
 ---
-- name: Ensure exactly one of (project_path, state_file) is set.
-  ansible.builtin.fail:
-    msg: Exactly one of (project_path, state_file) must be set.
-  when: project_path is defined == state_file is defined
-
 - name: Read outputs from project path
   cloud.terraform.terraform_output:
     project_path: "{{ project_path }}"
-    # state_file: "{{ state_file }}"
-  register: terraform_output_project_path
-  when: project_path is defined
-
-- name: Read outputs from state file
-  cloud.terraform.terraform_output:
     state_file: "{{ state_file }}"
-  register: terraform_output_state_file
-  when: state_file is defined
+  register: terraform_output
 
 - name: Add hosts from terraform_output to the group defined in terraform_output
   ansible.builtin.add_host:
@@ -24,7 +12,3 @@
     ansible_host: "{{ item[mapping_variables.ip] }}"
     ansible_user: "{{ item[mapping_variables.user] }}"
   loop: "{{ terraform_output.outputs[mapping_variables.host_list].value }}"
-  vars:
-    # even skipped tasks register variables, so we need to choose one explicitly
-    terraform_output: "{{ (terraform_output_project_path is defined and terraform_output_project_path is success) |
-                           ternary(terraform_output_project_path, terraform_output_state_file) }}"

--- a/tests/integration/targets/test_inventory_from_outputs/tasks/main.yml
+++ b/tests/integration/targets/test_inventory_from_outputs/tasks/main.yml
@@ -19,6 +19,7 @@
     name: cloud.terraform.inventory_from_outputs
   vars:
     project_path: "{{ test_basedir }}"
+    state_file: "{{ test_basedir }}/terraform.tfstate" # not necessary, can be null
     mapping_variables:
       host_list: myvar_hostlist
       name: myvar_name


### PR DESCRIPTION
##### SUMMARY
During development required_one_of(state_file, project_path) was removed from terraform_output module but we forgot to update the inventory_from_outputs role that uses the module.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
inventory_from_outputs role
