### PR TITLE
Add example of inventory definition in tf file

### DIFF
--- a/roles/inventory_from_outputs/README.md
+++ b/roles/inventory_from_outputs/README.md
@@ -38,7 +38,7 @@ Example Playbook
         - role: cloud.terraform.inventory_from_outputs
           project_path: 'my_project_directory'
           mapping_variables:
-            host_lists: terraform_var_host_list
+            host_list: terraform_var_host_list
             name: terraform_var_name
             ip: terraform_var_ip
             user: terraform_var_user

--- a/roles/inventory_from_outputs/README.md
+++ b/roles/inventory_from_outputs/README.md
@@ -44,6 +44,18 @@ Example Playbook
             user: terraform_var_user
             group: terraform_var_group
 
+Example of inventory definition in .tf file
+----------------
+```
+output "terraform_var_host_list" {
+  value = [
+    { "terraform_var_ip" : "my_ip1", "terraform_var_group" : "my_group1", "terraform_var_name" : "my_name1", "terraform_var_user" : "my_user" },
+    { "terraform_var_ip" : "my_ip2", "terraform_var_group" : "my_group2", "terraform_var_name" : "my_name2", "terraform_var_user" : "my_user" },
+    { "terraform_var_ip" : "my_ip3", "terraform_var_group" : "my_group1", "terraform_var_name" : "my_name3", "terraform_var_user" : "my_user" },
+  ]
+}
+```
+
 License
 -------
 


### PR DESCRIPTION
##### SUMMARY
For the role inventory_from_outputs a README.md file was updated - added example of inventory definition in .tf file.

##### ISSUE TYPE
Docs Pull Request
Fixes #40 

##### COMPONENT NAME
inventory_from_outputs/README.md