### PR TITLE
Update TerraformOutput model

### DIFF
--- a/changelogs/fragments/terraform_module_show_values_bugfix.yaml
+++ b/changelogs/fragments/terraform_module_show_values_bugfix.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Terraform module - fix now allows the possibility that the key "value" is not always present in the terraform plan thus avoiding KeyError.
+    (https://github.com/ansible-collections/cloud.terraform/pull/45)

--- a/plugins/module_utils/models.py
+++ b/plugins/module_utils/models.py
@@ -20,7 +20,7 @@ class TerraformOutput:
 
     @classmethod
     def from_json(cls, json: TJsonObject) -> "TerraformOutput":
-        return cls(sensitive=json["sensitive"], value=json["value"], type=json["type"])
+        return cls(sensitive=json.get("sensitive"), value=json.get("value"), type=json.get("type"))
 
 
 @dataclass


### PR DESCRIPTION
##### SUMMARY
In case where variables are used in output definition, that will be known after apply, "terraform show plan" will not show the "value" section for the output thus raising KeyError. This is now avoided using get() function in the TerraformOutput model.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
module_utils/models.py

##### ADDITIONAL INFORMATION
Fixes #42 
