### PR TITLE
Make binary_path validation PATH-aware

### DIFF
--- a/changelogs/fragments/49-command_name_in_binary_path.yaml
+++ b/changelogs/fragments/49-command_name_in_binary_path.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Accept Terraform executables present on PATH passed in as binary_path without specifying their absolute path. (https://github.com/ansible-collections/cloud.terraform/issues/49)

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -1,5 +1,6 @@
 import os
 import json
+import shutil
 from typing import List, Optional, Union, cast
 
 from ansible.module_utils.compat.version import LooseVersion
@@ -66,7 +67,7 @@ def validate_project_path(project_path: str) -> None:
 
 
 def validate_bin_path(bin_path: str) -> None:
-    if not os.path.exists(bin_path):
+    if not shutil.which(bin_path):
         raise TerraformError(
             "Path for Terraform binary '{0}' doesn't exist on this host - check the path and try again please.".format(
                 bin_path


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #49. I propose to replace the `os.path.exists` with [`shutil.which`](https://docs.python.org/3/library/shutil.html#shutil.which) to make the binary_path validation PATH-aware.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cloud.terraform

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

N/A