### PR TITLE
Add Terraform child module support for Inventory.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,14 +5,6 @@ The cloud.terraform collection Release Notes
 .. contents:: Topics
 
 
-v1.1.1
-======
-
-Major Changes
--------------
-
-- cloud.terraform.inventory searches the Terraform state for resources in child modules. 
-
 v1.1.0
 ======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ The cloud.terraform collection Release Notes
 .. contents:: Topics
 
 
+v1.1.1
+======
+
+Major Changes
+-------------
+
+- cloud.terraform.inventory searches the Terraform state for resources in child modules. 
+
 v1.1.0
 ======
 

--- a/changelogs/fragments/child_modules.yaml
+++ b/changelogs/fragments/child_modules.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - Added support for child modules in cloud.terraform.inventory. Child modules are common place in Terraform projects, so those need to be searched for
+    ansible_* Terraform resources.

--- a/plugins/module_utils/models.py
+++ b/plugins/module_utils/models.py
@@ -75,7 +75,13 @@ class TerraformRootModule:
 
     @classmethod
     def from_json(cls, json: TJsonObject) -> "TerraformRootModule":
-        return cls(resources=[TerraformRootModuleResource.from_json(r) for r in json.get("resources", [])])
+        root_resources = [TerraformRootModuleResource.from_json(r) for r in json.get("resources", [])]
+        child_resources = []
+        for cm in json.get("child_modules", []):
+            for r in TerraformRootModule.from_json(cm).resources:
+                child_resources.append(r)
+
+        return cls(resources=root_resources + child_resources)
 
 
 @dataclass


### PR DESCRIPTION
Added the ability to find child resources. Inventory was working for new terraform resource ansible_host in child modules.

##### SUMMARY
Ansible_host resources in Terraform child modules were not found. Routine for parsing the resource list was only looking at the root module. Since most Terraform projects use modules and submodules, the inventory needs to include nested ansible_host resources

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
cloud.terraform.module_utils

##### ADDITIONAL INFORMATION
Added code to search child modules of Terraform state.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

Before:
$ ansible-inventory -i inventory.yaml --graph --vars
@all:
  |--@ungrouped:

After:
$ ansible-inventory -i inventory.yaml --graph --vars
@all:
  |--@ungrouped:
  |--@group:
  |  |--router
  |  |  |--{ansible_become = yes}
  |  |  |--{ansible_become_method = enable}
  |  |  |--{ansible_connection = ansible.netcommon.network_cli}
  |  |  |--{ansible_network_os = cisco.ios.ios}


```
