### PR TITLE
Improve preflight validation

### DIFF
--- a/plugins/module_utils/terraform_commands.py
+++ b/plugins/module_utils/terraform_commands.py
@@ -215,7 +215,7 @@ class TerraformCommands:
         return TerraformShow.from_json(result)
 
     def validate(self, version: LooseVersion, variables_args: List[str]) -> None:
-        command = ["validate"]
+        command = ["validate", "-no-color"]
         if version < LooseVersion("0.15.0"):
             command += variables_args
         self._run(*command, check_rc=True)

--- a/plugins/modules/terraform.py
+++ b/plugins/modules/terraform.py
@@ -553,6 +553,8 @@ def main() -> None:
             for f in variables_files:
                 variables_args.extend(["-var-file", f])
 
+        preflight_validation(terraform, terraform_binary, project_path, checked_version, variables_args)
+
         # only use an existing plan file if we're not in the deprecated "planned" mode
         if plan_file and state != "planned":
             if not any([os.path.isfile(project_path + "/" + plan_file), os.path.isfile(plan_file)]):
@@ -585,8 +587,6 @@ def main() -> None:
             module.add_cleanup_file(new_plan_file)
             out = plan_stdout
             err = plan_stderr
-
-        preflight_validation(terraform, terraform_binary, project_path, checked_version, variables_args)
 
         try:
             planned_state = terraform.show(plan_file_to_apply)


### PR DESCRIPTION
##### SUMMARY
- Validate command should be run before terraform plan execution otherwise there is no point to do any validation.
- Validation error produces ANSI escape codes. Therefore we should use `-no-color` argument, see [this](https://github.com/ansible-collections/community.general/pull/5843) issue for more info.
