### PR TITLE
Fix spaces between characters in command field in result

### DIFF
--- a/changelogs/fragments/76-fix_command_spaces_in_output.yml
+++ b/changelogs/fragments/76-fix_command_spaces_in_output.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - fix spaces between characters in command field in result (https://github.com/ansible-collections/cloud.terraform/pull/76).

--- a/plugins/module_utils/terraform_commands.py
+++ b/plugins/module_utils/terraform_commands.py
@@ -76,7 +76,7 @@ class TerraformCommands:
                     cmd=" ".join(command),
                 )
 
-        return command, stdout, stderr
+        return " ".join(command), stdout, stderr
 
     def init(
         self,

--- a/plugins/module_utils/terraform_commands.py
+++ b/plugins/module_utils/terraform_commands.py
@@ -76,7 +76,7 @@ class TerraformCommands:
                     cmd=" ".join(command),
                 )
 
-        return " ".join(command), stdout, stderr
+        return command, stdout, stderr
 
     def init(
         self,

--- a/plugins/modules/terraform.py
+++ b/plugins/modules/terraform.py
@@ -649,7 +649,7 @@ def main() -> None:
             outputs=outputs,
             stdout=out,
             stderr=err,
-            command=" ".join(final_apply_command),
+            command=final_apply_command,
         )
     except TerraformError as e:
         e.fail_json(module)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #75 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Test Output
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
TASK [cloud.terraform.terraform] *******************************************************************************************************************************************
ok: [localhost] => {"changed": false, "command": "apply -no-color -input=false -auto-approve -lock=true /var/folders/qw/81hsrj450j760xkz3699lmjr0000gn/T/tmpovvbzpot.tfplan"
...
}
```
