### PR TITLE
CI - Create Github actions workflows to release collection

### DIFF
--- a/.github/workflows/galaxy_importer.yml
+++ b/.github/workflows/galaxy_importer.yml
@@ -1,0 +1,15 @@
+name: Galaxy
+on:
+  push:
+    branches:
+      - main
+      - stable-*
+  pull_request:
+    branches:
+      - main
+      - stable-*
+  schedule:
+    - cron: '0 13 * * *'
+jobs:
+  importer:
+    uses: ansible-network/github_actions/.github/workflows/galaxy_importer.yml@main

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,15 @@
+---
+name: Release
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    uses: ansible/devtools/.github/workflows/release_collection.yml@main
+    with:
+      environment: release
+    secrets:
+      ansible_galaxy_api_key: ${{ secrets.ANSIBLE_GALAXY_API_KEY }}
+      ah_token: ${{ secrets.ANSIBLE_AUTOMATION_HUB_TOKEN }}

--- a/.github/workflows/push-tag.yml
+++ b/.github/workflows/push-tag.yml
@@ -1,0 +1,22 @@
+---
+name: Release
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.sha }}'
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - stable-*
+
+jobs:
+  tag:
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: ansible-network/github_actions/.github/workflows/release-tag.yml@main
+    secrets:
+      gh_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+---
+name: Release
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.sha }}'
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "The version to release. e.g: '5.0.1'"
+        required: true
+
+jobs:
+  prepare:
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: ansible-network/github_actions/.github/workflows/release-branch.yml@main
+    with:
+      version: ${{ github.event.inputs.version }}

--- a/tox.ini
+++ b/tox.ini
@@ -66,3 +66,18 @@ commands =
   {[testenv:black]commands}
   {[testenv:mypy]commands}
   {[testenv:antsibull-docs]commands}
+
+[testenv:prepare_release]
+
+deps = 
+  packaging
+  yq
+  ansible
+  antsibull-changelog
+
+commands =
+  antsibull-changelog release --verbose --version '{env:RELEASE_VERSION}'
+  yq -yi ".version = \"{env:RELEASE_VERSION}\"" {toxinidir}/galaxy.yml
+
+passenv =
+    RELEASE_VERSION


### PR DESCRIPTION
Releasing should be triggered manually with the release tag, then once the pull request release is merged everything will be pushed to galaxy/automation hub