### PR TITLE
Fix integration test target terraform_provider

### DIFF
--- a/changelogs/fragments/20230914-fix-integration-target-terraform_provider.yml
+++ b/changelogs/fragments/20230914-fix-integration-target-terraform_provider.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - fix integration test target `terraform_provider`, add step to copy example modules into terraform working directory (https://github.com/ansible-collections/cloud.terraform/pull/89).

--- a/tests/integration/targets/terraform_provider/runme.sh
+++ b/tests/integration/targets/terraform_provider/runme.sh
@@ -6,6 +6,7 @@ set -eux
     mkdir -p subdir2/
     cp test.yml subdir2/
     cp ansible_provider.tf subdir2/
+    cp -r modules subdir2
     cd subdir2/
     terraform init
     terraform apply -auto-approve -state mycustomstate.tfstate
@@ -16,6 +17,7 @@ ansible-playbook -i localhost, -i inventory2.yml test.yml
     mkdir -p subdir3/
     cp test.yml subdir3/
     cp ansible_provider.tf subdir3/
+    cp -r modules subdir3
     cd subdir3/
     terraform init
     terraform apply -auto-approve
@@ -26,6 +28,7 @@ ansible-playbook -i localhost, -i inventory3.yml test.yml
     mkdir -p subdir4/
     cp test.yml subdir4/
     cp ansible_provider.tf subdir4/
+    cp -r modules subdir4
     cd subdir4/
     terraform init
     terraform apply -auto-approve -state mystate.tfstate

--- a/tests/integration/targets/terraform_provider/test.yml
+++ b/tests/integration/targets/terraform_provider/test.yml
@@ -22,7 +22,7 @@
           - "'somehost' in hostvars"
           - "'anotherhost' in hostvars"
           - "'childhost' in hostvars"
-          - "'nested_childhost' in hostvars"
+          - "'nested_childhost' not in hostvars"
 
 - name: Test host and group variables
   hosts: localhost


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Integration tests for `terraform_provider` are currently broken, this pull request aims to fix them.
Prior running `terraform init` we should copy modules into terraform working directory. This step is currently missing which is leading to an error.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Integration tests `terraform_provider`