### PR TITLE
add safe to test workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,9 +1,22 @@
 name: CI
 on:
   pull_request_target:
-
+    types:
+      - opened
+      - reopened
+      - labeled
+      - unlabeled
+      - synchronize
+    branches:
+      - main
+      - stable-*
 jobs:
+  safe-to-test:
+    if: ${{ github.event.label.name == 'safe to test' }} || ${{ github.event.action != 'labeled' }}
+    uses: ansible-network/github_actions/.github/workflows/safe-to-test.yml@main
   integration:
+    needs:
+      - safe-to-test
     runs-on: ubuntu-latest
     name: Integration (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }}+tf${{ matrix.terraform }})
     env:
@@ -30,6 +43,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: ${{ env.source }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Build and install collection
         id: install-collection


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The current workflow for integration tests is triggered by `pull_request_target` as it needs to access repository secrets to run the integration tests. The workflow currently runs the integration against the PR base branch code, this means that some PR merged can introduced errors in the CI (example with #55).

This PR adds an extra workflow `safe to test` which is used to protect against malicious code.
The integration workflow is going to checkout the PR head code, however a repository maintainer should add the label `safe to test` in order for the integration to run (this is automatically added for maintainers PRs)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
CI integration workflow