### PR TITLE
terraform - module should be able to generate plan file to a specified location

### DIFF
--- a/changelogs/fragments/20231016-fix-terraform-plan_file-option.yml
+++ b/changelogs/fragments/20231016-fix-terraform-plan_file-option.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - terraform - fix issue with ``plan_file`` option specified with ``check_mode=true`` and ``state`` set to one of ``present`` and ``absent``, the module is enable now to generate a Terraform file to the specified location (https://github.com/ansible-collections/cloud.terraform/issues/87).

--- a/tests/integration/targets/terraform_plan_file/aliases
+++ b/tests/integration/targets/terraform_plan_file/aliases
@@ -1,0 +1,1 @@
+terraform

--- a/tests/integration/targets/terraform_plan_file/files/main.tf
+++ b/tests/integration/targets/terraform_plan_file/files/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+    ansible = {
+      source  = "ansible/ansible"
+    }
+  }
+}
+
+variable "new_group" {
+    type = string
+    description = "additional host group"
+}
+
+resource "ansible_host" "my_host" {
+  name   = "localhost"
+  groups = ["ansible", var.new_group]
+  variables = {
+    ansible_user  = "ansible"
+    ansible_host  = "127.0.0.1"
+  }
+}
+
+output "host_groups" {
+  value = ansible_host.my_host.groups
+}

--- a/tests/integration/targets/terraform_plan_file/tasks/main.yml
+++ b/tests/integration/targets/terraform_plan_file/tasks/main.yml
@@ -1,0 +1,57 @@
+- name: Testing Terraform plan file custom location
+  block:
+    - name: Create temporary directory for terraform project
+      ansible.builtin.tempfile:
+        state: directory
+        suffix: ".terraform_plan_file"
+      register: tmpdir
+
+    - name: Copy terraform configuration into project path
+      ansible.builtin.copy:
+        src: "main.tf"
+        dest: "{{ tmpdir.path }}/main.tf"
+
+    - name: Create plan file using check_mode=true
+      cloud.terraform.terraform:
+        force_init: true
+        project_path: "{{ tmpdir.path }}"
+        plan_file: "{{ tmpdir.path }}/test.tfplan"
+        variables:
+          new_group: terraform
+      check_mode: true
+
+    - name: Ensure no resources were created
+      cloud.terraform.terraform_output:
+        project_path: "{{ tmpdir.path }}"
+      register: output
+      failed_when: output.outputs != {}
+
+    - name: Ensure plan file has been created
+      ansible.builtin.stat:
+        path: "{{ tmpdir.path }}/test.tfplan"
+      register: tfplan
+      failed_when: not tfplan.stat.exists
+
+    - name: Ensure state file has not been created
+      ansible.builtin.stat:
+        path: "{{ tmpdir.path }}/terraform.tfstate"
+      register: tfstate
+      failed_when: tfstate.stat.exists
+
+    - name: Apply Terraform generated plan file
+      cloud.terraform.terraform:
+        force_init: true
+        project_path: "{{ tmpdir.path }}"
+        plan_file: "{{ tmpdir.path }}/test.tfplan"
+
+    - name: Ensure plan file has been applied
+      cloud.terraform.terraform_output:
+        project_path: "{{ tmpdir.path }}"
+      register: output
+      failed_when: output.outputs.host_groups.value != ["ansible", "terraform"]
+
+  always:
+    - name: Delete temporary directory
+      ansible.builtin.file:
+        state: absent
+        path: "{{ tmpdir.path }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix issue when trying to generate plan file to a location specified with `plan_file` option and `state` set to one of `absent`, `present` in `check_mode=true`. The module was expecting the file to exist even if the user set `check_mode` to `true`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
closes #87 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`terraform`