### PR TITLE
CI - Update trigger for changelog job

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,6 +1,17 @@
 name: CI
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - labeled
+      - unlabeled
+      - synchronize
+    branches:
+      - main
+      - stable-*
+    tags:
+      - '*'
 
 jobs:
   changelog:


### PR DESCRIPTION
The `changelog` workflow was missing the `labeled` and `unlabeled` triggers
This allows to skip changelog validation after pull request creation