### PR TITLE
Remove superfluous param from get_bin_path

### DIFF
--- a/changelogs/fragments/get_bin_path.yml
+++ b/changelogs/fragments/get_bin_path.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Remove superfluous parameter ``required`` from process.get_bin_path API usage.

--- a/plugins/inventory/terraform_provider.py
+++ b/plugins/inventory/terraform_provider.py
@@ -107,6 +107,7 @@ EXAMPLES = r"""
 import os
 from typing import Any, List, Optional
 
+from ansible.errors import AnsibleError
 from ansible.module_utils.common import process
 from ansible_collections.cloud.terraform.plugins.module_utils.errors import TerraformError, TerraformWarning
 from ansible_collections.cloud.terraform.plugins.module_utils.models import (
@@ -191,7 +192,10 @@ class InventoryModule(TerraformInventoryPluginBase):
         if terraform_binary is not None:
             validate_bin_path(terraform_binary)
         else:
-            terraform_binary = process.get_bin_path("terraform", required=True)
+            try:
+                terraform_binary = process.get_bin_path("terraform")
+            except ValueError:
+                raise AnsibleError("Unable to find 'terraform' binary in the path")
 
         # TODO: remove when ansible provider is available
         state_content = []

--- a/plugins/lookup/tf_output.py
+++ b/plugins/lookup/tf_output.py
@@ -80,6 +80,7 @@ import os
 import subprocess
 from typing import Dict, List, Optional, Tuple
 
+from ansible.errors import AnsibleError
 from ansible.module_utils.common import process
 from ansible.plugins.lookup import LookupBase
 from ansible_collections.cloud.terraform.plugins.module_utils.types import AnyJsonType
@@ -111,7 +112,10 @@ class LookupModule(LookupBase):  # type: ignore  # cannot subclass without avail
         if bin_path is not None:
             terraform_binary = bin_path
         else:
-            terraform_binary = process.get_bin_path("terraform", required=True)
+            try:
+                terraform_binary = process.get_bin_path("terraform")
+            except ValueError:
+                raise AnsibleError("Unable to find 'terraform' binary in the path")
 
         output: List[AnyJsonType] = []
         if not terms:


### PR DESCRIPTION
##### SUMMARY

The parameter `required` in process.get_bin_path is useless.
Remove and update the usage of get_bin_path in inventory and lookup
plugins.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


