### PR TITLE
Fix integration test target awscc

### DIFF
--- a/changelogs/fragments/20240217-fix-awscc-integration-test.yaml
+++ b/changelogs/fragments/20240217-fix-awscc-integration-test.yaml
@@ -1,4 +1,4 @@
 ---
 trivial:
-  - fix integration test target ``awscc``.
+  - fix integration test target ``awscc`` (https://github.com/ansible-collections/cloud.terraform/pull/118).
 

--- a/changelogs/fragments/20240217-fix-awscc-integration-test.yaml
+++ b/changelogs/fragments/20240217-fix-awscc-integration-test.yaml
@@ -1,4 +1,3 @@
 ---
 trivial:
   - fix integration test target ``awscc`` (https://github.com/ansible-collections/cloud.terraform/pull/118).
-

--- a/changelogs/fragments/20240217-fix-awscc-integration-test.yaml
+++ b/changelogs/fragments/20240217-fix-awscc-integration-test.yaml
@@ -1,0 +1,4 @@
+---
+trivial:
+  - fix integration test target ``awscc``.
+

--- a/plugins/modules/terraform.py
+++ b/plugins/modules/terraform.py
@@ -564,7 +564,7 @@ def main() -> None:
             plan_file_to_apply = plan_file
             if not plan_file:
                 f, new_plan_file = tempfile.mkstemp(suffix=".tfplan")
-                module.add_cleanup_file(new_plan_file)
+                # module.add_cleanup_file(new_plan_file)
                 plan_file_to_apply = new_plan_file
 
             plan_result_changed, plan_result_any_destroyed, plan_stdout, plan_stderr = terraform.plan(

--- a/plugins/modules/terraform.py
+++ b/plugins/modules/terraform.py
@@ -564,7 +564,7 @@ def main() -> None:
             plan_file_to_apply = plan_file
             if not plan_file:
                 f, new_plan_file = tempfile.mkstemp(suffix=".tfplan")
-                # module.add_cleanup_file(new_plan_file)
+                module.add_cleanup_file(new_plan_file)
                 plan_file_to_apply = new_plan_file
 
             plan_result_changed, plan_result_any_destroyed, plan_stdout, plan_stderr = terraform.plan(

--- a/tests/integration/targets/awscc/files/cloud.tf
+++ b/tests/integration/targets/awscc/files/cloud.tf
@@ -10,26 +10,15 @@ terraform {
 provider "awscc" {
 }
 
-variable "cloud_terraform_integration_id" {
+variable "vpc_id" {
   type    = string
-  default = "jci93"
 }
 
 variable "cidr_block" {
   type    = string
-  default = "10.1.2.0/24"
 }
 
-resource "awscc_ec2_vpc" "test_vpc" {
+resource "awscc_ec2_subnet" "main" {
+  vpc_id     = var.vpc_id
   cidr_block = var.cidr_block
-  tags = [
-    {
-      key   = "Name",
-      value = var.cloud_terraform_integration_id,
-    },
-    {
-      key   = "cloud_terraform_integration",
-      value = "true",
-    },
-  ]
 }

--- a/tests/integration/targets/awscc/tasks/main.yml
+++ b/tests/integration/targets/awscc/tasks/main.yml
@@ -172,7 +172,7 @@
       with_items: "{{ subnet_info.subnets }}"
       ignore_errors: true
 
-    - name: Create VPC
+    - name: Delete VPC
       amazon.aws.ec2_vpc_net:
         name: "{{ vpc_name }}"
         cidr_block:

--- a/tests/integration/targets/awscc/tasks/main.yml
+++ b/tests/integration/targets/awscc/tasks/main.yml
@@ -11,7 +11,7 @@
   block:
     - set_fact:
         test_basedir: "{{ test_basedir | default(output_dir) }}"
-        resource_id: "{{ resource_prefix }}-awscc-vpc"
+        vpc_name: "{{ resource_prefix }}-awscc-vpc"
         vpc_cidr_block: '10.{{ 256 | random(seed=resource_prefix) }}.0.0/24'
 
     - name: Copy terraform files to workspace
@@ -21,27 +21,37 @@
       loop:
         - cloud.tf
 
+    - name: Create VPC
+      amazon.aws.ec2_vpc_net:
+        name: "{{ vpc_name }}"
+        cidr_block:
+          - "{{ vpc_cidr_block }}"
+        state: present
+      register: vpc_info
+
+    - set_fact:
+        vpc_id: "{{ vpc_info.vpc.id }}"
+
     - &verification
       block:
-        - name: Fetch VPC info
-          amazon.aws.ec2_vpc_net_info:
+        - name: Fetch Subnet info
+          amazon.aws.ec2_vpc_subnet_info:
             filters:
-              "tag:Name": "{{ resource_id }}"
-              "cidr": "{{ vpc_cidr_block }}"
-          register: vpc_info
+              vpc-id: "{{ vpc_id }}"
+              cidr-block: "{{ vpc_cidr_block }}"
+          register: subnet_info
 
-        - name: Assert that there are {{ number_of_vpcs }} VPCs with tag:Name={{ resource_id }} and cidr={{ vpc_cidr_block }}'
+        - name: Assert that there are {{ number_of_subnets }} Subnets
           assert:
             that:
-              - (vpc_info.vpcs | length) == number_of_vpcs
-        - name: Assert that VPC {{ resource_id }} is present and the info matches
+              - (subnet_info.subnets | length) == number_of_subnets
+        - name: Assert that Subnet  is present and the info matches
           assert:
             that:
-              - vpc_info.vpcs[0].cidr_block == "{{ vpc_cidr_block }}"
-              - vpc_info.vpcs[0].tags.Name == "{{ resource_id }}"
-          when: number_of_vpcs == 1
+              - subnet_info.subnets[0].cidr_block == vpc_cidr_block
+          when: number_of_subnets == 1
       vars:
-        number_of_vpcs: 0
+        number_of_subnets: 0
 
     - name: Terraform in present check mode
       cloud.terraform.terraform:
@@ -49,7 +59,7 @@
         state: present
         force_init: true
         variables:
-          cloud_terraform_integration_id: "{{ resource_id }}"
+          vpc_id: "{{ vpc_id }}"
           cidr_block: "{{ vpc_cidr_block }}"
       register: terraform_result
       check_mode: true
@@ -61,7 +71,7 @@
 
     - <<: *verification
       vars:
-        number_of_vpcs: 0
+        number_of_subnets: 0
 
     - name: Terraform in present non-check mode
       cloud.terraform.terraform:
@@ -69,7 +79,7 @@
         state: present
         force_init: true
         variables:
-          cloud_terraform_integration_id: "{{ resource_id }}"
+          vpc_id: "{{ vpc_id }}"
           cidr_block: "{{ vpc_cidr_block }}"
       register: terraform_result
       check_mode: false
@@ -81,7 +91,7 @@
 
     - <<: *verification
       vars:
-        number_of_vpcs: 1
+        number_of_subnets: 1
 
     - name: Terraform in present non-check mode (idempotency)
       cloud.terraform.terraform:
@@ -89,7 +99,7 @@
         state: present
         force_init: true
         variables:
-          cloud_terraform_integration_id: "{{ resource_id }}"
+          vpc_id: "{{ vpc_id }}"
           cidr_block: "{{ vpc_cidr_block }}"
       register: terraform_result
       check_mode: false
@@ -101,7 +111,7 @@
 
     - <<: *verification
       vars:
-        number_of_vpcs: 1
+        number_of_subnets: 1
 
     - name: Terraform in absent check mode
       cloud.terraform.terraform:
@@ -109,7 +119,7 @@
         state: absent
         force_init: true
         variables:
-          cloud_terraform_integration_id: "{{ resource_id }}"
+          vpc_id: "{{ vpc_id }}"
           cidr_block: "{{ vpc_cidr_block }}"
       register: terraform_result
       check_mode: true
@@ -121,7 +131,7 @@
 
     - <<: *verification
       vars:
-        number_of_vpcs: 1
+        number_of_subnets: 1
 
     - name: Terraform in absent non-check mode
       cloud.terraform.terraform:
@@ -129,7 +139,7 @@
         state: absent
         force_init: true
         variables:
-          cloud_terraform_integration_id: "{{ resource_id }}"
+          vpc_id: "{{ vpc_id }}"
           cidr_block: "{{ vpc_cidr_block }}"
       register: terraform_result
       check_mode: false
@@ -141,21 +151,31 @@
 
     - <<: *verification
       vars:
-        number_of_vpcs: 0
+        number_of_subnets: 0
 
   # Clean up all integration test resources
   always:
-    - name: Fetch VPC info
-      amazon.aws.ec2_vpc_net_info:
+    - name: Fetch Subnet info
+      amazon.aws.ec2_vpc_subnet_info:
         filters:
-          "tag:Name": "{{ resource_id }}"
-          "cidr": "{{ vpc_cidr_block }}"
-      register: vpc_info
+          vpc-id: "{{ vpc_id }}"
+          cidr-block: "{{ vpc_cidr_block }}"
+      register: subnet_info
       ignore_errors: true
 
-    - name: Delete VPC
-      amazon.aws.ec2_vpc_net:
-        vpc_id: "{{ item.vpc_id }}"
+    - name: Delete Subnets
+      amazon.aws.ec2_vpc_subnet:
+        cidr: "{{ item.cidr_block }}"
+        vpc_id: "{{ vpc_id }}"
+        wait: true
         state: absent
-      loop: "{{ vpc_info.vpcs }}"
+      with_items: "{{ subnet_info.subnets }}"
+      ignore_errors: true
+
+    - name: Create VPC
+      amazon.aws.ec2_vpc_net:
+        name: "{{ vpc_name }}"
+        cidr_block:
+          - "{{ vpc_cidr_block }}"
+        state: absent
       ignore_errors: true


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The test target `awscc` is failing inconsistently on the `idempotency` validation.
Terraform reports changed because it is trying to destroy and recreate the vpc resource.
The fix consists in creating a VPC subnet resource.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`integration test awscc`
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
