### PR TITLE
Inventory terraform_state - add azurerm vm types

### DIFF
--- a/plugins/inventory/terraform_state.py
+++ b/plugins/inventory/terraform_state.py
@@ -399,7 +399,8 @@ class TerraformProviderInstance:
 ProvidersMapping = {
     "aws": TerraformProviderInstance(provider_name="registry.terraform.io/hashicorp/aws", types=["aws_instance"]),
     "azurerm": TerraformProviderInstance(
-        provider_name="registry.terraform.io/hashicorp/azurerm", types=["azurerm_virtual_machine"]
+        provider_name="registry.terraform.io/hashicorp/azurerm",
+        types=["azurerm_virtual_machine", "azurerm_linux_virtual_machine", "azurerm_windows_virtual_machine"],
     ),
     "google": TerraformProviderInstance(
         provider_name="registry.terraform.io/hashicorp/google", types=["google_compute_instance"]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Add azurerm vm types `azurerm_linux_virtual_machine` and `azurerm_windows_virtual_machine`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

- `terraform_state` inventory plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

The official Terraform documentation states the following: 

>The azurerm_virtual_machine resource has been superseded by the [azurerm_linux_virtual_machine](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine) and [azurerm_windows_virtual_machine](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/windows_virtual_machine) resources.

My environment test.

```
$ ansible-inventory -i terraform_state.yml --graph --vars
@all:
  |--@ungrouped:
  |  |--azurerm_linux_virtual_machine_vm-linux    # provisioned by resource azurerm_linux_virtual_machine
  ...
  |  |  |--{source_image_reference = [{'offer': 'UbuntuServer', 'publisher': 'Canonical', 'sku': '16.04-LTS', 'version': 'latest'}]}
  ...
  |  |--azurerm_windows_virtual_machine_vm-win  # provisioned by resource azurerm_windows_virtual_machine_vm
  ...
  |  |  |--{source_image_reference = [{'offer': 'WindowsServer', 'publisher': 'MicrosoftWindowsServer', 'sku': '2022-datacenter-azure-edition', 'version': 'latest'}]}
```

