### PR TITLE
Inventory terraform_state - improve backend_config_files option description

### DIFF
--- a/plugins/inventory/terraform_state.py
+++ b/plugins/inventory/terraform_state.py
@@ -38,7 +38,7 @@ options:
     type: dict
   backend_config_files:
     description:
-      - The path to a configuration file to provide at init state to the -backend-config parameter.
+      - The absolute path to a configuration file to provide at init state to the -backend-config parameter.
         This can accept a list of paths to multiple configuration files.
     type: list
     elements: path


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

The backend_config_files option of terraform_state inventory plugin should be specify absolute path. 

Due to terraform init command be executed at temporary directory, terraform can not find he backend config file that specified with related path.

In addition to example absolute path `/path/to/config1`, I explicitly added it to the description.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
N/A
```
