### PR TITLE
Inventory terraform_state - supports groups

### DIFF
--- a/plugins/inventory/terraform_state.py
+++ b/plugins/inventory/terraform_state.py
@@ -517,6 +517,7 @@ class InventoryModule(TerraformInventoryPluginBase, Constructable):  # type: ign
         hostnames: Optional[List[Any]],
         compose: Optional[Dict[str, str]],
         keyed_groups: List[Dict[str, Any]],
+        groups: Dict[str, Any],
         strict: bool,
     ) -> None:
         for instance in instances:
@@ -535,6 +536,9 @@ class InventoryModule(TerraformInventoryPluginBase, Constructable):  # type: ign
 
                 # Create groups based on variable values and add the corresponding hosts to it
                 self._add_host_to_keyed_groups(keyed_groups, host_vars, name, strict=strict)
+
+                # Create groups based on jinja2 conditionals
+                self._add_host_to_composed_groups(groups, host_vars, name, strict=strict)
 
     def parse(self, inventory, loader, path, cache=False):  # type: ignore  # mypy ignore
         super(InventoryModule, self).parse(inventory, loader, path, cache=cache)
@@ -574,5 +578,10 @@ class InventoryModule(TerraformInventoryPluginBase, Constructable):  # type: ign
             providers,
         )
         self.create_inventory(
-            instances, cfg.get("hostnames"), cfg.get("compose"), cfg.get("keyed_groups"), cfg.get("strict")
+            instances,
+            cfg.get("hostnames"),
+            cfg.get("compose"),
+            cfg.get("keyed_groups"),
+            cfg.get("groups"),
+            cfg.get("strict"),
         )

--- a/tests/integration/targets/inventory_terraform_state_aws/templates/inventory_with_constructed.yml.j2
+++ b/tests/integration/targets/inventory_terraform_state_aws/templates/inventory_with_constructed.yml.j2
@@ -6,7 +6,9 @@ backend_config:
   key: ansible/terraform.tfstate
   region: {{ aws_region }}
 keyed_groups:
-- key: instance_state
-  prefix: state
-- prefix: tag
-  key: tags
+  - key: instance_state
+    prefix: state
+  - prefix: tag
+    key: tags
+groups:
+  no_public_ip: public_ip == ""

--- a/tests/integration/targets/inventory_terraform_state_aws/test.yml
+++ b/tests/integration/targets/inventory_terraform_state_aws/test.yml
@@ -118,6 +118,8 @@
               - default_hostname in groups.tag_Phase_integration
               - "'state_running' in groups"
               - default_hostname in groups.state_running
+              - "'no_public_ip' in groups"
+              - default_hostname in groups.no_public_ip
 
       always:
         - name: Delete temporary file

--- a/tests/unit/plugins/inventory/test_terraform_state.py
+++ b/tests/unit/plugins/inventory/test_terraform_state.py
@@ -258,6 +258,7 @@ class TestInventoryModuleCreateInventory:
     def test_create_inventory(self, inventory_plugin, mocker):
         hostnames = MagicMock()
         keyed_groups = MagicMock()
+        groups = MagicMock()
         strict = MagicMock()
         compose = MagicMock()
 
@@ -270,9 +271,10 @@ class TestInventoryModuleCreateInventory:
 
         inventory_plugin._set_composite_vars = MagicMock()
         inventory_plugin._add_host_to_keyed_groups = MagicMock()
+        inventory_plugin._add_host_to_composed_groups = MagicMock()
         inventory_plugin.inventory = self.ansibleInventory()
 
-        inventory_plugin.create_inventory(instances, hostnames, compose, keyed_groups, strict)
+        inventory_plugin.create_inventory(instances, hostnames, compose, keyed_groups, groups, strict)
 
         for name, value in config.items():
             inventory_plugin.inventory.assert_value(name, value)
@@ -287,6 +289,10 @@ class TestInventoryModuleCreateInventory:
         )
         inventory_plugin._add_host_to_keyed_groups.assert_has_calls(
             [call(keyed_groups, vars, name, strict=strict) for name, vars in config.items()],
+            any_order=True,
+        )
+        inventory_plugin._add_host_to_composed_groups.assert_has_calls(
+            [call(groups, vars, name, strict=strict) for name, vars in config.items()],
             any_order=True,
         )
 
@@ -428,6 +434,7 @@ class TestInventoryModuleParse:
             config.get("hostnames"),
             config.get("compose"),
             config.get("keyed_groups"),
+            config.get("groups"),
             config.get("strict"),
         )
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Supports `groups`.


```yaml
---
plugin: cloud.terraform.terraform_state
backend_type: s3
backend_config:
  bucket: {{ bucket_name }}
  key: ansible/terraform.tfstate
  region: {{ aws_region }}
keyed_groups:
  - key: instance_state
    prefix: state
  - prefix: tag
    key: tags
groups:    # here
  no_public_ip: public_ip == ""
```
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

- `terraform_state` inventory plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
