### PR TITLE
Add GH release automation workflows

### DIFF
--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -1,0 +1,36 @@
+---
+name: Generate GitHub Release (manual trigger)
+concurrency:
+  group: release-${{ github.head_ref }}
+  cancel-in-progress: true
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        required: true
+        description: Release to generate
+        type: string
+
+jobs:
+  generate-release-log:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Release Log
+        uses: ansible-collections/amazon.aws/.github/actions/ansible_release_log@main
+        with:
+          release: ${{ inputs.release }}
+
+  perform-release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    needs:
+      - generate-release-log
+    steps:
+      - name: Generate Release
+        uses: ansible-collections/amazon.aws/.github/actions/ansible_release_tag@main
+        with:
+          release: ${{ inputs.release }}
+          collection-name: cloud.terraform

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -8,7 +8,7 @@ on:
     inputs:
       release:
         required: true
-        description: Existing tag to generate release for (example: 3.0.0)
+        description: "Existing tag to generate release for (example: 3.0.0)"
         type: string
 
 jobs:

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -8,7 +8,7 @@ on:
     inputs:
       release:
         required: true
-        description: Release to generate
+        description: Existing tag to generate release for (example: 3.0.0)
         type: string
 
 jobs:

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,33 @@
+---
+name: Generate GitHub Release
+concurrency:
+  group: release-${{ github.head_ref }}
+  cancel-in-progress: true
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  generate-release-log:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Release Log
+        uses: ansible-collections/amazon.aws/.github/actions/ansible_release_log@main
+        with:
+          release: ${{ github.ref_name }}
+
+  perform-release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    needs:
+      - generate-release-log
+    steps:
+      - name: Generate Release
+        uses: ansible-collections/amazon.aws/.github/actions/ansible_release_tag@main
+        with:
+          release: ${{ github.ref_name }}
+          collection-name: cloud.terraform


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This adds two new GHA workflows for automating the creation of GH releases from tags. It uses the actions from the amazon.aws repo and adds the same workflows for automatically creating a GH release when a new tag is created and for manually tiggering the workflow for an existing tag.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
