### PR TITLE
Add 2.14 to supported ansible versions for lint

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -4,3 +4,6 @@ profile: production
 exclude_paths:
   - changelogs/changelog.yaml
   - tests/integration
+
+supported_ansible_also:
+  - "2.14"


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Ansible lint checks that the requires_ansible resolves to a supported version of Ansible. This is a problem for major versions we still support that have an older minimum required version of ansible. Version 24.6.0 of ansible-lint added a new config option to relax the requires_ansible version check.

This PR is only against the stable-2 branch.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
