### PR TITLE
add module arg corresponding to cli refresh flag

### DIFF
--- a/changelogs/fragments/20250121-add-refresh-arg.yml
+++ b/changelogs/fragments/20250121-add-refresh-arg.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Use "refresh" arg on plan command line (i.e. "terraform plan
+    -refresh=<arg>", defaults true), and allow user override in module args
+    (https://github.com/ansible-collections/cloud.terraform/pull/168)

--- a/plugins/module_utils/terraform_commands.py
+++ b/plugins/module_utils/terraform_commands.py
@@ -107,6 +107,7 @@ class TerraformCommands:
         target_plan_file_path: str,
         targets: List[str],
         destroy: bool,
+        refresh: bool,
         state_args: List[str],
         variables_args: List[str],
     ) -> Tuple[bool, bool, str, str]:
@@ -123,6 +124,7 @@ class TerraformCommands:
             command.extend(["-target", t])
         if destroy:
             command.append("-destroy")
+        command.append(f"-refresh={refresh}")
         command.extend(state_args)
         command.extend(variables_args)
 

--- a/plugins/modules/terraform.py
+++ b/plugins/modules/terraform.py
@@ -129,6 +129,15 @@ options:
         that accepts locks (such as S3+DynamoDB).
     type: int
     version_added: 1.0.0
+  refresh:
+    description:
+      - Boolean argument for the C(-refresh=) option, to freshen terraform
+        resource/data state during Plan generation.  State refresh normally
+        happens by default, but can be countermanded by giving a C(false)
+        value here.
+    type: bool
+    default: true
+    version_added: 1.0.0
   force_init:
     description:
       - To avoid duplicating infra, if a state file can't be found this will
@@ -445,6 +454,7 @@ def main() -> None:
             lock=dict(type="bool", default=True),
             lock_timeout=dict(type="int"),
             force_init=dict(type="bool", default=False),
+            refresh=dict(type="bool", default=True),
             backend_config=dict(type="dict"),
             backend_config_files=dict(type="list", elements="path"),
             init_reconfigure=dict(type="bool", default=False),
@@ -570,6 +580,7 @@ def main() -> None:
             plan_result_changed, plan_result_any_destroyed, plan_stdout, plan_stderr = terraform.plan(
                 target_plan_file_path=plan_file_to_apply,
                 targets=module.params.get("targets"),
+                refresh=module.params.get("refresh", True),
                 destroy=state == "absent",
                 state_args=get_state_args(state_file),
                 variables_args=variables_args,


### PR DESCRIPTION
This patch adds `-refresh=true` to the plan generation command line (which is the default if not specified), and adds a module argument `refresh` with default `true` value, so user can override and make sure resources are not refreshed for a specific module run.  This way, `plan` can be called with `-refresh=false` when a user knows they want this.

My use case: while implementing an image bake pipeline that uses Terraform to provision and Ansible to configure a node to be imaged, my play ends by cleaning out the cloud-init identity, shutting down the node, and then imaging the node.  Unfortunately, the state refresh that happens prior to imaging wakes up the node, and then it can't be imaged.  So I have a chicken-egg situation where I cannot plan the imaging step without waking up the node, whereas waking up the node prevents imaging.

Using `-refresh=false` during plan phase fixes this for my use case.  I think it's a valuable flag to expose to other users of the Ansible Terraform module.

Terraform source code has the first reference to `-refresh=` flag very early, in June 2014, so don't think we need a version check for this.
