### PR TITLE
Variables parameter set to no_log=True

### DIFF
--- a/plugins/modules/terraform.py
+++ b/plugins/modules/terraform.py
@@ -436,7 +436,7 @@ def main() -> None:
             workspace=dict(type="str", default="default"),
             purge_workspace=dict(type="bool", default=False),
             state=dict(default="present", choices=["present", "absent", "planned"]),
-            variables=dict(type="dict"),
+            variables=dict(type="dict", no_log=True),
             complex_vars=dict(type="bool", default=False),
             variables_files=dict(aliases=["variables_file"], type="list", elements="path"),
             plan_file=dict(type="path"),


### PR DESCRIPTION
##### SUMMARY
The `variables` parameter often includes sensitive data. While `no_log=true` can be set on the task level (as suggested in the module's documentation), this hinders efforts to debug module usage during the plan or apply stages of Terraform. It would make more sense just to define the `variables` parameters to be hidden (as some other Ansible modules do).

Based on [AAPRFE-1929](https://issues.redhat.com/browse/AAPRFE-1929).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`cloud.terraform.terraform`

##### ADDITIONAL INFORMATION
An even better solution would be to have a new parameter which could switch the `variables` visibility to on/off. I'd need some help with that though.
