### PR TITLE
AAP-47584: Docstring update for terraform_output module

### DIFF
--- a/plugins/modules/terraform_output.py
+++ b/plugins/modules/terraform_output.py
@@ -44,6 +44,7 @@ options:
       - If I(state_file) and I(project_path) are not specified, the C(terraform.tfstate) file in the
         current working directory will be used.
       - The C(TF_DATA_DIR) environment variable is respected.
+      - This option is not compatible for remote states
     type: path
     version_added: 1.0.0
   workspace:


### PR DESCRIPTION
##### SUMMARY
The changes aims at updating the doctring for the terraform_module parameter- state_file according to [documentation link](https://developer.hashicorp.com/terraform/cli/commands/output#:~:text=Path%20to%20the%20state%20file.%20Defaults%20to%20%22terraform.tfstate%22.%20Ignored%20when%20remote%20state%20is%20used)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
terraform_output module

##### ADDITIONAL INFORMATION
None
