### PR TITLE
updating documentation for lookup plugin

### DIFF
--- a/docs/cloud.terraform.tf_output_lookup.rst
+++ b/docs/cloud.terraform.tf_output_lookup.rst
@@ -105,6 +105,7 @@ Parameters
                         <div>The path to an existing Terraform state file whose outputs will be listed.</div>
                         <div>If <em>state_file</em> and <em>project_path</em> are not specified, the <code>terraform.tfstate</code> file in the current working directory will be used.</div>
                         <div>The <code>TF_DATA_DIR</code> environment variable is respected.</div>
+                        <div> This option is not compatible for remote states.</div>
                 </td>
             </tr>
             <tr>

--- a/plugins/lookup/tf_output.py
+++ b/plugins/lookup/tf_output.py
@@ -27,6 +27,7 @@ options:
       - If I(state_file) and I(project_path) are not specified, the C(terraform.tfstate) file in the
         current working directory will be used.
       - The C(TF_DATA_DIR) environment variable is respected.
+      - This option is not comptabile for remote states.
     type: path
   binary_path:
     description:


### PR DESCRIPTION
##### SUMMARY
Updating the doctring for the lookup plugin terraform_output, parameter- state_file according to [documentation link](https://developer.hashicorp.com/terraform/cli/commands/output#:~:text=Path%20to%20the%20state%20file.%20Defaults%20to%20%22terraform.tfstate%22.%20Ignored%20when%20remote%20state%20is%20used)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lookup plugin: cloud.terraform.tf_output

##### ADDITIONAL INFORMATION
None