### PR TITLE
Indentation fix for doc in terraform state inventory plugin

### DIFF
--- a/docs/cloud.terraform.terraform_state_inventory.rst
+++ b/docs/cloud.terraform.terraform_state_inventory.rst
@@ -799,7 +799,7 @@ Examples
         hostname: app.terraform.io
         organization: redhat
         workspaces:
-        prefix: ansible-
+          prefix: ansible-
 
     # Using the cloud block (see below the corresponding Terraform configuration)
     # terraform {


### PR DESCRIPTION
##### SUMMARY
Indentation fix for doc of terraform state inventory plugin



##### ISSUE TYPE

- Docs Pull Request


##### COMPONENT NAME
terraform state inventory doc

