### PR TITLE
AAP46677 - Update workspace logic

### DIFF
--- a/changelogs/fragments/20250630-terraform-review-workspace-logic.yaml
+++ b/changelogs/fragments/20250630-terraform-review-workspace-logic.yaml
@@ -1,0 +1,5 @@
+---
+breaking_changes:
+  - terraform - The default value `default` for the `workspace` argument has been removed (https://github.com/ansible-collections/cloud.terraform/pull/200).
+minor_changes:
+  - terraform - Update module logic to determine workspace (https://github.com/ansible-collections/cloud.terraform/pull/200).

--- a/tests/integration/targets/terraform_workspace/README.md
+++ b/tests/integration/targets/terraform_workspace/README.md
@@ -1,0 +1,18 @@
+# terraform_workspace integration test target
+
+## Requirements
+
+A valid HCP Terraform / Terraform Entreprise cloud account.
+Set the variables `terraform_organization_name` and `terraform_organization_token` into `inventory.yaml`
+
+
+## Workspace configuration
+
+Create the following workspaces:
+
+| **Name** | **Tags** |
+| -------------- | --------------------- |
+| ansible_default | `project=ansible` |
+| ansible_default_with_tags | `project=ansible`, `default=true` |
+| ansible_cloud_config |  |
+

--- a/tests/integration/targets/terraform_workspace/aliases
+++ b/tests/integration/targets/terraform_workspace/aliases
@@ -1,0 +1,1 @@
+disabled # Requires HCP terraform / Terraform Entreprise credentials

--- a/tests/integration/targets/terraform_workspace/inventory.yaml
+++ b/tests/integration/targets/terraform_workspace/inventory.yaml
@@ -1,0 +1,29 @@
+all:
+  hosts:
+    default:
+      terraform_workspace_name: "ansible_default"
+      result_workspace: "ansible_default"
+      run_terraform_init: true
+    default_with_tags:
+      terraform_workspace_tags:
+        project: "ansible"
+        default: "true"
+      result_workspace: "ansible_default_with_tags"
+      force_init: true
+    workspace_match_cloud_config:
+      terraform_workspace_name: "ansible_cloud_config"
+      module_workspace: "ansible_cloud_config"
+      run_terraform_init: true
+    workspace_missmatch_cloud_config:
+      terraform_workspace_name: "ansible_default_with_tags"
+      module_workspace: "ansible_default"
+      force_init: true
+      error_message: "Invalid workspaces configuration"
+    multiple_match:
+      terraform_workspace_tags:
+        project: "ansible"
+      force_init: true
+      error_message: 'Currently selected workspace "default" does not exist'
+  vars:
+    terraform_organization_name: 
+    terraform_organization_token: 

--- a/tests/integration/targets/terraform_workspace/playbooks/files/main.tf
+++ b/tests/integration/targets/terraform_workspace/playbooks/files/main.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+    }
+  }
+}
+
+resource "local_file" "foo" {
+  content  = "This file has been generated using Terraform on Ansible."
+  filename = "${path.module}/foo.txt"
+}

--- a/tests/integration/targets/terraform_workspace/playbooks/run.yml
+++ b/tests/integration/targets/terraform_workspace/playbooks/run.yml
@@ -1,0 +1,72 @@
+- hosts: all
+  gather_facts: false
+  strategy: linear
+
+  vars:
+    ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
+
+  tasks:
+    - name: Ensure terraform organization name has been defined
+      ansible.builtin.fail:
+        msg: "Terraform organization name should be defined using 'terraform_organization_name'"
+      when: terraform_organization_name is undefined
+
+    - name: Ensure terraform organization token has been defined
+      ansible.builtin.fail:
+        msg: "Terraform organization token should be defined using 'terraform_organization_token'"
+      when: terraform_organization_token is undefined  
+
+    - name: Create temporary directory for the terraform configuration
+      ansible.builtin.tempfile:
+        state: directory
+        suffix: .tf
+      register: tfdir
+
+    - name: Run tests
+      block:
+        - name: Copy terraform configuration into temporary directory
+          ansible.builtin.copy:
+            src: "main.tf"
+            dest: "{{ tfdir.path }}/main.tf"
+
+        - name: Create provider configuration
+          ansible.builtin.template:
+            src: "provider.tf.j2"
+            dest: "{{ tfdir.path }}/provider.tf"
+
+        - name: Run terraform init into the project directory
+          ansible.builtin.command:
+            cmd: terraform init -input=false
+            chdir: "{{ tfdir.path }}"
+          when: run_terraform_init | default(false) | bool
+
+        - name: Deploy terraform resources
+          cloud.terraform.terraform:
+            project_path: "{{ tfdir.path }}"
+            state: present
+            force_init: "{{ force_init | default(omit) }}"
+            workspace: "{{ module_workspace | default(omit) }}"
+          register: tf_run
+          ignore_errors: true
+
+        - name: Ensure module has failed with the appropriate message
+          ansible.builtin.assert:
+            that:
+              - tf_run is failed
+              - error_message in tf_run.msg
+          when: error_message is defined
+
+        - name: Validate that module run successfully
+          ansible.builtin.assert:
+            that:
+              - tf_run is successful
+              - tf_run.workspace == (module_workspace | default(result_workspace))
+          when: error_message is undefined
+      
+      always:
+        - name: Delete temporary directory
+          ansible.builtin.file:
+            state: absent
+            path: "{{ tfdir.path }}"
+          ignore_errors: true

--- a/tests/integration/targets/terraform_workspace/playbooks/templates/provider.tf.j2
+++ b/tests/integration/targets/terraform_workspace/playbooks/templates/provider.tf.j2
@@ -1,0 +1,21 @@
+terraform {
+  cloud {
+    organization = "{{ terraform_organization_name }}"
+    token = "{{ terraform_organization_token }}"
+    workspaces {
+{% if terraform_workspace_project | default(false) %}
+      project = "{{ terraform_workspace_project }}"
+{% endif %}
+{% if terraform_workspace_name | default(false) %}
+      name = "{{ terraform_workspace_name }}"
+{% endif %}
+{% if terraform_workspace_tags | default(false) %}
+      tags = {
+      {% for key, value in terraform_workspace_tags.items() %}
+        {{ key }} = "{{ value }}"
+      {% endfor %}
+      }
+{% endif %}
+    }
+  }
+}

--- a/tests/integration/targets/terraform_workspace/runme.sh
+++ b/tests/integration/targets/terraform_workspace/runme.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -eux
+
+ansible-playbook playbooks/run.yml -i inventory.yaml "$@"

--- a/tests/unit/plugins/module_utils/test_terraform_commands.py
+++ b/tests/unit/plugins/module_utils/test_terraform_commands.py
@@ -23,6 +23,21 @@ class TestTerraformCommands:
         # therefore the test will pass if self.run_command_fp(...) was called
         self.mock.assert_called_with(["/binary/path"] + args, cwd="/project/path", check_rc=False)
 
+    def test_run_with_workspace(self):
+        args = ["apply", "-no-color", "-input=false"]
+        self.tf.tfworkspace = "foo"
+        self.tf._run(*args, check_rc=False)
+
+        # Testing if self.run_command_fp(...) was called.
+        # self.run_command_fp(...) should be called in this method,
+        # therefore the test will pass if self.run_command_fp(...) was called
+        self.mock.assert_called_with(
+            ["/binary/path"] + args,
+            cwd="/project/path",
+            check_rc=False,
+            environ_update={"TF_WORKSPACE": self.tf.tfworkspace},
+        )
+
     def test_apply_plan(self):
         self.mock.return_value = (self.rc, self.stdout, self.stderr)
         self.tf._run = self.mock
@@ -55,6 +70,7 @@ class TestTerraformCommands:
     # Test init method; NOT __init__
     def test_init(self):
         self.tf._run = self.mock
+        self.mock.return_value = (self.rc, self.stdout, self.stderr)
         self.tf.init(
             backend_config={"test_val": "test"},
             backend_config_files=["config_file"],
@@ -77,7 +93,7 @@ class TestTerraformCommands:
             "/plugin/path",
         ]
 
-        self.mock.assert_called_with(*expected_cmd, check_rc=True)
+        self.mock.assert_called_with(*expected_cmd, check_rc=False)
 
     def test_plan(self):
         self.mock.return_value = (self.rc, self.stdout, self.stderr)


### PR DESCRIPTION
##### SUMMARY
Refers to [AAP-46677](https://issues.redhat.com/plugins/servlet/samlsso?redirectTo=%2Fbrowse%2FAAP-46677)
Replaces #194 and #197 

- Breaking change: Remove the default value `default` for the workspace argument. When the user runs `terraform init`, it may use a different workspace value. When running apply on the directory, we should use the current workspace value (retrieved using `terraform workspace show`) instead of always defaulting to `default`. In case not set, the CLI will automatically default to the `default` value.
- Update workspace logic
   - In case the user has provided a `workspace` argument, this will be set into the `TF_WORKSPACE` environment for all `terraform` commands. If the value differs from the one in the `cloud` configuration block, the CLI will raise an error.
   - In case the user has not provided a `workspace` argument the CLI will determine the workspace using either the `cloud` configuration block or the `default` value.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`terraform`