### PR TITLE
Allow Jinja templating in inventory configuration values

### DIFF
--- a/plugins/inventory/terraform_provider.py
+++ b/plugins/inventory/terraform_provider.py
@@ -185,9 +185,24 @@ class InventoryModule(TerraformInventoryPluginBase):
         cfg = self._read_config_data(path)
 
         project_path = cfg.get("project_path", os.getcwd())
+        try:
+            project_path = self.templar.template(project_path, fail_on_undefined=False)
+        except Exception as exc:
+            self.warn(f"Failed to template 'project_path': {exc}")
+
         state_file = cfg.get("state_file", "")
+        try:
+            state_file = self.templar.template(state_file, fail_on_undefined=False)
+        except Exception as exc:
+            self.warn(f"Failed to template 'state_file': {exc}")
+
         search_child_modules = cfg.get("search_child_modules", True)
         terraform_binary = cfg.get("binary_path", None)
+        if terraform_binary is not None:
+            try:
+                terraform_binary = self.templar.template(terraform_binary, fail_on_undefined=False)
+            except Exception as exc:
+                self.warn(f"Failed to template 'binary_path': {exc}")
         if terraform_binary is not None:
             validate_bin_path(terraform_binary)
         else:

--- a/plugins/inventory/terraform_state.py
+++ b/plugins/inventory/terraform_state.py
@@ -738,10 +738,39 @@ class InventoryModule(TerraformInventoryPluginBase, Constructable):  # type: ign
         cfg = self._read_config_data(path)
 
         backend_config = cfg.get("backend_config")
+        if backend_config is not None:
+            try:
+                backend_config = self.templar.template(backend_config, fail_on_undefined=False)
+            except Exception as exc:
+                self.warn(f"Failed to template 'backend_config': {exc}")
+
         backend_config_files = cfg.get("backend_config_files")
+        if backend_config_files is not None:
+            try:
+                backend_config_files = self.templar.template(backend_config_files, fail_on_undefined=False)
+            except Exception as exc:
+                self.warn(f"Failed to template 'backend_config_files': {exc}")
+
         backend_type = cfg.get("backend_type")
+        if backend_type is not None:
+            try:
+                backend_type = self.templar.template(backend_type, fail_on_undefined=False)
+            except Exception as exc:
+                self.warn(f"Failed to template 'backend_type': {exc}")
+
         provider_mapping = cfg.get("provider_mapping", [])
+        if provider_mapping:
+            try:
+                provider_mapping = self.templar.template(provider_mapping, fail_on_undefined=False)
+            except Exception as exc:
+                self.warn(f"Failed to template 'provider_mapping': {exc}")
+
         terraform_binary = cfg.get("binary_path")
+        if terraform_binary is not None:
+            try:
+                terraform_binary = self.templar.template(terraform_binary, fail_on_undefined=False)
+            except Exception as exc:
+                self.warn(f"Failed to template 'binary_path': {exc}")
         search_child_modules = cfg.get("search_child_modules", False)
 
         if not backend_type:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Update the inventory plugins to allow templating variable values.

Currently, the inventory plugins require the configuration values to be included in plain-text. This is suboptimal for values such as the `password` value when configuring an HTTP backend. This change allows the plugins to parse templates when setting the values in the inventory plugin configs. For example, this allows a user to use a lookup plugin to set the backend authorization values from an external secret manager or from an environment variable.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`terraform_state`
`terraform_provider`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Example inventory file:
```yaml
plugin: cloud.terraform.terraform_state
backend_type: http
backend_config:
  address: https://gitlab.example.com/api/v4/projects/1/terraform/state/default
  lock_address: https://gitlab.example.com/api/v4/projects/1/terraform/state/default/lock
  unlock_address: https://gitlab.example.com/api/v4/projects/1/terraform/state/default/lock
  username: "{{ lookup('env','TF_STATE_USER') }}"
  password: "{{ lookup('env','TF_STATE_PASSWORD') }}"
```

Output from current version:
```
[WARNING]: Failed to parse inventory with 'auto' plugin: Error refreshing state: HTTP remote state endpoint requires auth

Failed to parse inventory with 'auto' plugin.

<<< caused by >>>

Error refreshing state: HTTP remote state endpoint requires auth
Origin: <inventory plugin 'auto' with source '/path/to/ansible/inventory/terraform_state.yml'>

[WARNING]: Failed to parse inventory with 'yaml' plugin: Plugin configuration YAML file, not YAML inventory

Failed to parse inventory with 'yaml' plugin.

<<< caused by >>>

Plugin configuration YAML file, not YAML inventory
Origin: <inventory plugin 'yaml' with source '/path/to/ansible/inventory/terraform_state.yml'>

[WARNING]: Failed to parse inventory with 'ansible_collections.cloud.terraform.plugins.inventory.terraform_state' plugin: Error refreshing state: HTTP remote state endpoint requires auth

Failed to parse inventory with 'ansible_collections.cloud.terraform.plugins.inventory.terraform_state' plugin.

<<< caused by >>>

Error refreshing state: HTTP remote state endpoint requires auth
Origin: <inventory plugin 'ansible_collections.cloud.terraform.plugins.inventory.terraform_state' with source '/path/to/ansible/inventory/terraform_state.yml'>

[WARNING]: Unable to parse /path/to/ansible/inventory/terraform_state.yml as an inventory source
```
